### PR TITLE
Correcciones jstrappa

### DIFF
--- a/02-explore.Rmd
+++ b/02-explore.Rmd
@@ -14,8 +14,8 @@ En esta parte del libro aprenderás algunas herramientas útiles que tienen un b
 
 * La visualización por sí sola a menudo no es suficiente, por lo que en [transformación de datos] aprenderás los verbos clave que te permitirán seleccionar variables importantes, filtrar observaciones, crear nuevas variables y calcular estadísticos que resuman información.
 
-* Finalmente, en [análisis exploratorio de datos (_EDA_)] vas a combinar visualización y transformación con tu curiosidad y escepticismo para formular y responder preguntas en torno a los datos.
+* Finalmente, en [análisis exploratorio de datos (_EDA_)], vas a combinar visualización y transformación con tu curiosidad y escepticismo para formular y responder preguntas en torno a los datos.
 
-Si bien el modelamiento es un aspecto importante del proceso exploratorio, aún no tienes las habilidades para aprenderlo con efectividad o aplicarlo. Volveremos sobre este tema en el [capítulo introductorio de Modelos](#model-intro), una vez que ya tengas las herramientas de manejo de datos y programación.
+Si bien el modelado es un aspecto importante del proceso exploratorio, aún no tienes las habilidades para aprenderlo con efectividad o aplicarlo. Volveremos sobre este tema en el [capítulo introductorio de Modelos](#model-intro), una vez que ya tengas las herramientas de manejo de datos y programación.
 
 Entre estos tres capítulos que enseñan las herramientas de exploración de datos hay otros tres capítulos que se enfocan en el flujo de trabajo en R. En [flujo de trabajo: conocimientos básicos], [flujo de trabajo: Scripts] y [flujo de trabajo: proyectos] aprenderás buenas prácticas para escribir y organizar tu código en R. Estas prácticas te prepararán para el éxito a largo plazo, en términos de que te entregan las herramientas necesarias para organizarte cuando abordes proyectos reales.

--- a/03-visualize.Rmd
+++ b/03-visualize.Rmd
@@ -61,7 +61,7 @@ Usemos nuestro primer gráfico para responder una pregunta: ¿los automóviles c
 
 ### El _data frame_ `millas`
 
-Puedes poner a prueba tu respuesta empleando el _data frame_ `millas` que se encuentra en el paquete **datos** (`datos::millas`). Un _data frame_ es una colección rectangular de variables (columnas) y observaciones (filas). El _data frame_ `millas` contiene observaciones para 38 modelos de automóviles recopiladas por la Agencia de Protección Ambiental de los EE. UU.
+Puedes poner a prueba tu respuesta empleando el _data frame_ `millas` que se encuentra en el paquete **datos** (conocido como `datos::millas`). Un _data frame_ es una colección rectangular de variables (columnas) y observaciones (filas). El _data frame_ `millas` contiene observaciones para 38 modelos de automóviles recopiladas por la Agencia de Protección Ambiental de los EE. UU.
 
 ```{r}
 millas

--- a/24-model-building.Rmd
+++ b/24-model-building.Rmd
@@ -459,7 +459,7 @@ Vemos un patrón fuerte en el número de vuelos de los sábados. Esto es tranqui
 
 Solo hemos dado una pincelada sobre el tema de modelos, pero es de esperar que hayas adquirido algunas herramientas simples, pero de uso general que puedes usar para mejorar tus propios análisis. ¡Está bien empezar de manera simple! Como has visto, incluso modelos muy simples pueden significar una gran diferencia en tu habilidad para desentrañar las interacciones o pueden generar un incremento dramático en tu habilidad para desentrañar las interacciones.
 
-Estos capítulos de modelos son aún más dogmáticos que el resto del libro. Yo enfoco el modelamiento desde una perspectiva diferente a la mayoría, y hay relativamente poco espacio dedicado a ello. El modelamiento realmente requiere un libro completo, así que recomiendo que leas alguno de estos 3 libros:
+Estos capítulos de modelos son aún más dogmáticos que el resto del libro. Yo enfoco el modelado desde una perspectiva diferente a la mayoría, y hay relativamente poco espacio dedicado a ello. El modelado realmente requiere un libro completo, así que recomiendo que leas alguno de estos 3 libros:
 
 * *Statistical Modeling: A Fresh Approach* by Danny Kaplan,
   <http://project-mosaic-books.com/?page_id=13>. Este libro provee
@@ -471,7 +471,7 @@ Estos capítulos de modelos son aún más dogmáticos que el resto del libro. Yo
 * *An Introduction to Statistical Learning* by Gareth James, Daniela Witten, 
   Trevor Hastie, and Robert Tibshirani, <http://www-bcf.usc.edu/~gareth/ISL/> 
   (Disponible en línea gratis). Este libro presenta una moderna familia de 
-  técnicas de modelamiento colectivamente conocidas como aprendizaje estadístico.
+  técnicas de modelado colectivamente conocidas como aprendizaje estadístico.
   Para una más profunda comprensión de la matemática detrás de los modelos, lee el clásico
   *Elements of Statistical Learning* por Trevor Hastie, Robert Tibshirani, y
   Jerome Friedman, <http://statweb.stanford.edu/~tibs/ElemStatLearn/> (También


### PR DESCRIPTION
1) Desambigüé una frase entre paréntesis que podía llevar a confusión con la sintaxis de R. Decía "en el paquete datos (datos::millas)" y lo cambié a "en el paquete datos (conocido como datos::millas)". Una persona que acababa de comenzar a aprender R me dijo que pensó que esto era una función 'datos(datos::millas)' y estuvo mucho tiempo sin poder entender por qué obtenía error. 

2) Cambié el uso de "modelamiento", que me suena un poco rebuscado, y no era consistente con el resto del libro (se usa "modelado"; también podría ser "modelización").
